### PR TITLE
Fix/cst 106 multi scenario

### DIFF
--- a/src/pages/TA/UserRqInputModel.tsx
+++ b/src/pages/TA/UserRqInputModel.tsx
@@ -117,6 +117,15 @@ export const useUserRqInputModel = () => {
   const targetProjectId = state?.targetProjectId;
   const dashboardGroupId = executionIds[0];
 
+  // ID를 통해 시나리오 라벨(예: '로그인')을 찾아주는 함수
+  const getScenarioLabel = (id: string) => {
+    for (const category of SCENARIO_DATA) {
+      const item = category.items.find((it) => it.id === id);
+      if (item) return item.label;
+    }
+    return '';
+  };
+
   const handleNext = async () => {
     if (!canProceed) return;
     // 1. 모달 열기 및 초기화
@@ -140,14 +149,23 @@ export const useUserRqInputModel = () => {
       // Request Body에 맞춰 Set에 저장된 시나리오 문자열 ID들을 배열로 변환
       const scenarioIdsAsStrings = Array.from(selectedIds);
 
-      // 3. 선택된 타겟 레포지토리 수만큼 병렬로 API (POST) 반복 호출
-      const promises = repoIds.map((repoId) => {
-        return setupTest(projectId, {
-          baseTestGroupName: testName,
-          targetRepoId: Number(repoId), 
-          scenarioSerials: scenarioIdsAsStrings,
-          targetBranch: "main", // 하드코딩 반영
-          optionalServerUrl: state?.serverUrl, // 선택적으로 서버 URL 전달
+      // 2. 조건부 테스트명 조합 및 API 호출 로직 변경
+      const promises = repoIds.flatMap((repoId) => {
+        return Array.from(selectedIds).map((scenarioId) => {
+          const scenarioLabel = getScenarioLabel(scenarioId);
+          
+          // ✨ 핵심 변경 사항: 선택된 시나리오가 2개 이상일 때만 (라벨) 추가
+          const customizedTestName = selectedIds.size > 1 
+            ? `${testName} (${scenarioLabel})` 
+            : testName;
+
+          return setupTest(projectId, {
+            baseTestGroupName: customizedTestName,
+            targetRepoId: Number(repoId),
+            scenarioSerials: [scenarioId], // 단일 시나리오 ID 전송
+            targetBranch: "main",
+            optionalServerUrl: state?.serverUrl,
+          });
         });
       });
 

--- a/src/pages/TA/UserRqInputModel.tsx
+++ b/src/pages/TA/UserRqInputModel.tsx
@@ -1,7 +1,7 @@
 // src/pages/Home/TA/UserRqInputModel.tsx
 import { useState, useRef, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import { setupTest, downloadTestPlan, dispatchTest, fetchExecutionStatus } from '../../api/test';
+import { setupTest, downloadTestPlan, dispatchTest, fetchExecutionStatus, checkTestNameDuplicate } from '../../api/test';
 
 export interface ScenarioItem {
   id: string;
@@ -90,7 +90,9 @@ export const useUserRqInputModel = () => {
     serverUrl?: string;
   };
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [testName] = useState(state?.testName || 'Test A');
+  const [testName, setTestName] = useState(state?.testName || 'Test A'); // setTestName 추가
+  const [isEditingTestName, setIsEditingTestName] = useState(false); // 편집 모드 상태
+  const [testNameError, setTestNameError] = useState(''); // 에러 메시지 상태
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [planStatus, setPlanStatus] = useState<'generating' | 'complete'>('generating');
@@ -124,6 +126,34 @@ export const useUserRqInputModel = () => {
       if (item) return item.label;
     }
     return '';
+  };
+
+  // [추가] 테스트명 저장 로직 (TFSelect와 동일)
+  const handleSaveTestName = async () => {
+    const trimmedName = testName.trim();
+    
+    if (trimmedName === '') {
+      setTestNameError('테스트명을 입력해주세요.');
+      return;
+    }
+
+    try {
+      const projectId = state?.targetProjectId;
+      if (!projectId) throw new Error("프로젝트 ID가 없습니다.");
+
+      // API를 통한 중복 체크
+      const isDuplicated = await checkTestNameDuplicate(projectId, trimmedName);
+      
+      if (isDuplicated) {
+        setTestNameError('해당 프로젝트에 이미 존재하는 테스트명입니다.');
+      } else {
+        setTestNameError('');
+        setIsEditingTestName(false); // 성공 시 편집 모드 종료
+      }
+    } catch (error) {
+      console.error("테스트명 중복 체크 실패:", error);
+      setTestNameError('중복 체크 중 오류가 발생했습니다.');
+    }
   };
 
   const handleNext = async () => {
@@ -314,6 +344,11 @@ export const useUserRqInputModel = () => {
 
   return {
     testName,
+    setTestName,
+    isEditingTestName,
+    setIsEditingTestName,
+    testNameError,
+    handleSaveTestName,
     scenarios: SCENARIO_DATA,
     selectedIds,
     toggleScenario,

--- a/src/pages/TA/UserRqInputModel.tsx
+++ b/src/pages/TA/UserRqInputModel.tsx
@@ -181,7 +181,7 @@ export const useUserRqInputModel = () => {
 
       // 2. 조건부 테스트명 조합 및 API 호출 로직 변경
       const promises = repoIds.flatMap((repoId) => {
-        return Array.from(selectedIds).map((scenarioId) => {
+        return scenarioIdsAsStrings.map((scenarioId) => {
           const scenarioLabel = getScenarioLabel(scenarioId);
           
           // ✨ 핵심 변경 사항: 선택된 시나리오가 2개 이상일 때만 (라벨) 추가

--- a/src/pages/TA/UserRqInputView.tsx
+++ b/src/pages/TA/UserRqInputView.tsx
@@ -6,6 +6,9 @@ import TestDownloadModal from "../../components/common/Modal/TestDownloadModal";
 import TestCompleteModal from "../../components/common/Modal/TestCompleteModal";
 import type { TestProcessStage } from "./UserRqInputModel";
 
+import InputField from "../../components/common/InputField";
+import { Button } from "../../components/common/Button";
+
 import PencilIcon from "../../assets/icons/pencil.svg?react";
 import PersonIcon from "../../assets/icons/person.svg?react";
 import KeyIcon from "../../assets/icons/key.svg?react";
@@ -16,6 +19,11 @@ import EtcIcon from "../../assets/icons/etc.svg?react";
 
 interface Props {
   testName: string;
+  setTestName: (val: string) => void;
+  isEditingTestName: boolean;
+  setIsEditingTestName: (val: boolean) => void;
+  testNameError: string;
+  handleSaveTestName: () => void;
   scenarios: ScenarioCategory[];
   selectedIds: Set<string>;
   toggleScenario: (id: string) => void;
@@ -50,6 +58,11 @@ const ICON_MAP: Record<string, React.ReactNode> = {
 
 export default function UserRqInputView({
   testName,
+  setTestName,
+  isEditingTestName,
+  setIsEditingTestName,
+  testNameError,
+  handleSaveTestName,
   scenarios,
   selectedIds,
   toggleScenario,
@@ -82,15 +95,41 @@ export default function UserRqInputView({
   const isGenerating = planStatus === "generating";
 
   return (
-    <div className="flex w-full min-h-screen bg-grayscale-white">
+    <div className="w-full h-[calc(100vh-5rem)] mt-20 flex bg-grayscale-white relative">
       {/* 1. Sidebar */}
       <aside className="w-overlay-side-sheet self-stretch px-gap-xl py-16 bg-grayscale-white flex flex-col gap-14 border-r border-grayscale-gy200/50">
-        <div className="self-stretch pl-2 py-2 flex justify-between items-center">
-          <span className="text-h3-ko text-grayscale-black">{testName}</span>
-          <button className="p-1 rounded-lg hover:bg-grayscale-gy100">
-            <PencilIcon className="w-6 h-6 [&_*]:fill-grayscale-black" />
-          </button>
-        </div>
+        {isEditingTestName ? (
+          // [편집 모드] InputField + 저장 버튼 (TFSelect와 동일 로직)
+          <div className="self-stretch flex flex-col justify-start items-center gap-3">
+            <InputField
+              value={testName}
+              onChange={(e) => setTestName(e.target.value)}
+              showIcon={false}
+              placeholder="Test Name"
+              widthClass="w-full"
+              isError={testNameError.length > 0}
+              errorMessage={testNameError}
+            />
+            <Button 
+              variant="dynamicSg500SText" 
+              onClick={handleSaveTestName}
+              disabled={testName.trim() === ''}
+            >
+              저장
+            </Button>
+          </div>
+        ) : (
+          // [기본 모드] 테스트명 표시 + 연필 아이콘
+          <div className="self-stretch pl-2 py-2 flex justify-between items-center">
+            <span className="text-h3-ko text-grayscale-black truncate">{testName}</span>
+            <button 
+              className="p-1 rounded-lg hover:bg-grayscale-gy100"
+              onClick={() => setIsEditingTestName(true)}
+            >
+              <PencilIcon className="w-6 h-6 [&_*]:fill-grayscale-black" />
+            </button>
+          </div>
+        )}
       </aside>
 
       {/* 2. Main Content */}


### PR DESCRIPTION
---
name: 새로운 기능
about: 새로운 기능을 제안합니다.
title: '[FEATURE] 테스트 시나리오 분리 생성 및 테스트명 편집 기능 구현'
labels: 'fix'
assignees: '여인범'
---

## 📝 PR 설명
사용자 요구사항 입력(UserRqInput) 화면에서 다중 시나리오 선택 시 개별 테스트로 분리하여 생성하는 로직을 구현하고, 사이드바에서 테스트명을 실시간으로 수정 및 중복 체크할 수 있는 기능을 추가했습니다.

## 🛠 주요 변경 사항
- **다중 시나리오 분리 생성 로직 구현**
  - `selectedIds`를 순회하며 시나리오별로 `setupTest` API를 개별 호출하도록 변경했습니다.
  - 선택된 시나리오가 2개 이상일 경우 `테스트명 (시나리오명)` 형태로 이름이 자동 조합되도록 개선했습니다.
  - 단일 시나리오 선택 시에는 기존 입력한 테스트명을 그대로 유지합니다.
- **테스트명 편집 및 중복 체크 기능 추가**
  - `TestFileSelect` 페이지와 동일한 방식의 이름 수정 UI 및 `checkTestNameDuplicate` API 연동을 완료했습니다.
  - 편집 모드 상태 관리(`isEditingTestName`) 및 에러 메시지 처리를 추가했습니다.
- **레이아웃 및 여백 조정**
  - 글로벌 헤더와의 간격을 위해 최상위 컨테이너에 `mt-20` 및 높이 계산 로직(`h-[calc(100vh-5rem)]`)을 적용했습니다.

## 🧪 테스트 체크리스트
- [x] 시나리오를 3개 선택하고 '다음' 클릭 시, 3개의 테스트 계획서가 각각 생성되는지 확인
- [x] 생성 완료 후 다운로드 시 3개의 파일이 순차적으로 다운로드되는지 확인
- [x] 다중 선택 시 이름이 `명칭 (시나리오)` 형식으로 생성되는지 확인
- [x] 사이드바 연필 아이콘 클릭 시 입력창으로 전환되는지 확인
- [x] 이미 존재하는 테스트명 입력 시 중복 에러 메시지가 정상 노출되는지 확인

## 📸 스크린샷 또는 비디오
## ➕ 추가 사항
- 현재 `executionIds` 배열을 통해 모든 테스트의 상태를 폴링하고 있으며, 모든 테스트가 완료되어야 결과 모달로 진입합니다.

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 코드를 제거했습니다
- [x] 주석 처리를 필요한 만큼 하였습니다.
- [x] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다 (해당 시)

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)