### PR TITLE
feat: 401 응답 시 accesstoken 자동 재발급

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,5 +1,11 @@
-import { axiosInstance, publicAxiosInstance } from "./axios";
 import { LOCAL_STORAGE_KEY } from "../constants/key";
+
+import { axiosInstance, publicAxiosInstance } from "./axios";
+
+type AccessTokenResponse = {
+  access_token?: string;
+  accessToken?: string;
+};
 
 export function extractAccessTokenFromUrl(search: string) {
   const params = new URLSearchParams(search);
@@ -20,16 +26,19 @@ export function clearAuthStorage() {
   localStorage.removeItem(LOCAL_STORAGE_KEY.refreshToken);
 }
 
-export async function reissueAccessToken() {
-  const response = await publicAxiosInstance.post("/api/auth/reissue", {});
-  const accessToken =
-    response.data?.access_token ?? response.data?.accessToken;
-
-  if (!accessToken) {
-    throw new Error("No access_token from reissue");
+function extractAccessTokenFromResponse(data: unknown) {
+  if (!data || typeof data !== "object") {
+    return null;
   }
 
-  return accessToken;
+  const tokenResponse = data as AccessTokenResponse;
+  return tokenResponse.access_token ?? tokenResponse.accessToken ?? null;
+}
+
+export async function reissueAccessToken() {
+  const response = await publicAxiosInstance.post("/api/auth/reissue", {});
+
+  return extractAccessTokenFromResponse(response.data);
 }
 
 // 로그아웃 (서버가 Set-Cookie로 refresh/access/JSESSIONID 만료 처리해줘야 함)

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,5 +1,15 @@
-import axios from "axios";
+import axios, { AxiosHeaders, type InternalAxiosRequestConfig } from "axios";
+
 import { LOCAL_STORAGE_KEY } from "../constants/key";
+
+type RetriableRequestConfig = InternalAxiosRequestConfig & {
+  _retry?: boolean;
+};
+
+type AccessTokenResponse = {
+  access_token?: string;
+  accessToken?: string;
+};
 
 export const publicAxiosInstance = axios.create({
   baseURL: import.meta.env.VITE_SERVER_API_URL,
@@ -12,6 +22,47 @@ export const axiosInstance = axios.create({
   withCredentials: true,
   timeout: 15000,
 });
+
+let reissuePromise: Promise<string | null> | null = null;
+
+function extractAccessToken(data: unknown) {
+  if (!data || typeof data !== "object") {
+    return null;
+  }
+
+  const tokenResponse = data as AccessTokenResponse;
+  return tokenResponse.access_token ?? tokenResponse.accessToken ?? null;
+}
+
+function clearStoredAuth() {
+  window.localStorage.removeItem(LOCAL_STORAGE_KEY.accessToken);
+  window.localStorage.removeItem(LOCAL_STORAGE_KEY.refreshToken);
+}
+
+async function reissueAccessTokenOnce() {
+  if (!reissuePromise) {
+    reissuePromise = publicAxiosInstance
+      .post("/api/auth/reissue", {})
+      .then((response) => extractAccessToken(response.data))
+      .finally(() => {
+        reissuePromise = null;
+      });
+  }
+
+  return reissuePromise;
+}
+
+function setAuthorizationHeader(config: RetriableRequestConfig, token: string) {
+  const headers = AxiosHeaders.from(config.headers);
+  headers.set("Authorization", `Bearer ${token}`);
+  config.headers = headers;
+}
+
+function removeAuthorizationHeader(config: RetriableRequestConfig) {
+  const headers = AxiosHeaders.from(config.headers);
+  headers.delete("Authorization");
+  config.headers = headers;
+}
 
 axiosInstance.interceptors.request.use((config) => {
   const token = window.localStorage.getItem(LOCAL_STORAGE_KEY.accessToken);
@@ -33,10 +84,47 @@ axiosInstance.interceptors.response.use(
     console.log("[axios response] data:", response.data);
     return response;
   },
-  (error) => {
+  async (error: unknown) => {
+    if (!axios.isAxiosError(error)) {
+      return Promise.reject(error);
+    }
+
     console.log("[axios response] 실패");
     console.log("[axios response] status:", error?.response?.status);
     console.log("[axios response] data:", error?.response?.data);
-    return Promise.reject(error);
+
+    const originalRequest = error.config as RetriableRequestConfig | undefined;
+
+    if (
+      error.response?.status !== 401 ||
+      !originalRequest ||
+      originalRequest._retry
+    ) {
+      return Promise.reject(error);
+    }
+
+    originalRequest._retry = true;
+
+    try {
+      const newAccessToken = await reissueAccessTokenOnce();
+
+      if (newAccessToken) {
+        window.localStorage.setItem(
+          LOCAL_STORAGE_KEY.accessToken,
+          newAccessToken
+        );
+        setAuthorizationHeader(originalRequest, newAccessToken);
+      } else {
+        window.localStorage.removeItem(LOCAL_STORAGE_KEY.accessToken);
+        removeAuthorizationHeader(originalRequest);
+      }
+
+      console.log("[axios response] 토큰 재발급 후 원래 요청 재시도");
+      return axiosInstance(originalRequest);
+    } catch (reissueError) {
+      clearStoredAuth();
+      console.log("[axios response] 토큰 재발급 실패:", reissueError);
+      return Promise.reject(reissueError);
+    }
   }
 );

--- a/src/pages/OAuthRedirect.tsx
+++ b/src/pages/OAuthRedirect.tsx
@@ -34,7 +34,11 @@ export default function OAuthRedirect() {
 
       try {
         const newAccessToken = await reissueAccessToken();
-        saveAccessToken(newAccessToken);
+        if (newAccessToken) {
+          saveAccessToken(newAccessToken);
+        } else {
+          clearAccessToken();
+        }
         setMessage("토큰 재발급 성공, 홈으로 이동 중...");
         navigate("/home", { replace: true });
       } catch (e) {


### PR DESCRIPTION
---
name: 새로운 기능
about: 새로운 기능을 제안합니다.
title: '[FEATURE] 401 응답 시 토큰 자동 재발급 처리'
labels: 
assignees: ''
---

## 📝 PR 설명
Access Token 만료로 API 요청이 401 응답을 받을 경우, Refresh Token 기반 재발급 API를 호출한 뒤 기존 요청을 자동으로 재시도하도록 처리했습니다.

## 🛠 주요 변경 사항
- Axios 응답 인터셉터에서 401 응답 감지 시 `/api/auth/reissue` 호출
- 토큰 재발급 성공 후 기존 실패 요청 자동 재시도
- 동시에 여러 요청이 401을 받아도 재발급 요청은 한 번만 실행되도록 처리
- reissue 응답이 JSON 토큰 또는 쿠키 기반 재발급인 경우를 모두 대응

## 🧪 테스트 체크리스트
- [x] Access Token 만료 상태에서 API 요청 시 401 응답을 받는지 확인
- [x] 401 응답 후 `/api/auth/reissue`가 호출되는지 확인
- [x] 토큰 재발급 후 기존 API 요청이 자동 재시도되는지 확인
- [x] 재시도한 API 요청이 정상적으로 200 응답을 받는지 확인

## 📸 스크린샷 또는 비디오
<img width="301" height="269" alt="image" src="https://github.com/user-attachments/assets/dfa6db9b-6a7d-4e1c-a001-7d9fb8c467b3" />


## ➕ 추가 사항
현재 백엔드 reissue API는 쿠키 기반으로 토큰을 재발급할 수 있어, 응답 body에 access token이 없는 경우도 정상 흐름으로 처리했습니다.

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 코드를 제거했습니다
- [x] 주석 처리를 필요한 만큼 하였습니다.
- [x] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)