### PR TITLE
Fix/cst 110 second qa

### DIFF
--- a/src/components/common/ListItem/TestCodeListItem.tsx
+++ b/src/components/common/ListItem/TestCodeListItem.tsx
@@ -85,7 +85,7 @@ const TestCodeListItem = forwardRef<HTMLDivElement, TestCodeListItemProps>(
             onClick?.(e);
           }
         }}
-        className={`group gap-m px-gap-s py-gap-s border-grayscale-gy300 bg-grayscale-white relative inline-flex w-full items-center border-b transition-colors duration-200 ${!disabled && 'hover:bg-grayscale-gy100 active:bg-grayscale-gy200'} ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'} ${className || ''} `}
+        className={`group gap-5 pl-4 pr-3 py-4 border-grayscale-gy300 bg-grayscale-white relative inline-flex w-full items-center border-b transition-colors duration-200 ${!disabled && 'hover:bg-grayscale-gy100 active:bg-grayscale-gy200'} ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'} ${className || ''} `}
         {...rest}
       >
         {/* 1. ID */}

--- a/src/components/common/ListItem/TestListItem.tsx
+++ b/src/components/common/ListItem/TestListItem.tsx
@@ -93,7 +93,7 @@ const TestListItem = forwardRef<HTMLDivElement, TestListItemProps>(
           }
         }}
         className={`
-          group relative w-full inline-flex items-center gap-m px-gap-s py-gap-s
+          group relative w-full inline-flex items-center gap-5 pl-4 pr-3 py-4
           border-b border-grayscale-gy300
           transition-colors duration-200
           

--- a/src/pages/TA/UserRqInputModel.tsx
+++ b/src/pages/TA/UserRqInputModel.tsx
@@ -1,7 +1,7 @@
 // src/pages/Home/TA/UserRqInputModel.tsx
 import { useState, useRef, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { setupTest, downloadTestPlan, dispatchTest, fetchExecutionStatus, checkTestNameDuplicate } from '../../api/test';
+import { setupTest, downloadTestPlan, dispatchTest, fetchExecutionStatus } from '../../api/test';
 
 export interface ScenarioItem {
   id: string;
@@ -119,15 +119,6 @@ export const useUserRqInputModel = () => {
   const [executionIds, setExecutionIds] = useState<number[]>([]);
   const targetProjectId = state?.targetProjectId;
   const dashboardGroupId = executionIds[0];
-
-  // ID를 통해 시나리오 라벨(예: '로그인')을 찾아주는 함수
-  const getScenarioLabel = (id: string) => {
-    for (const category of SCENARIO_DATA) {
-      const item = category.items.find((it) => it.id === id);
-      if (item) return item.label;
-    }
-    return '';
-  };
 
   // [추가] 테스트명 저장 로직 (TFSelect와 동일)
   const handleSaveTestName = async () => {

--- a/src/pages/TA/UserRqInputModel.tsx
+++ b/src/pages/TA/UserRqInputModel.tsx
@@ -1,6 +1,6 @@
 // src/pages/Home/TA/UserRqInputModel.tsx
 import { useState, useRef, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { setupTest, downloadTestPlan, dispatchTest, fetchExecutionStatus, checkTestNameDuplicate } from '../../api/test';
 
 export interface ScenarioItem {
@@ -82,6 +82,7 @@ const SCENARIO_DATA: ScenarioCategory[] = [
 export type TestProcessStage = "idle" | "generating" | "testing" | "complete";
 
 export const useUserRqInputModel = () => {
+  const navigate = useNavigate();
   const location = useLocation();
   const state = location.state as {
     testName?: string;
@@ -90,7 +91,7 @@ export const useUserRqInputModel = () => {
     serverUrl?: string;
   };
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [testName, setTestName] = useState(state?.testName || 'Test A'); // setTestName 추가
+  const [testName, setTestName] = useState(state?.testName ?? ''); // setTestName 추가
   const [isEditingTestName, setIsEditingTestName] = useState(false); // 편집 모드 상태
   const [testNameError, setTestNameError] = useState(''); // 에러 메시지 상태
 
@@ -138,21 +139,22 @@ export const useUserRqInputModel = () => {
     }
 
     try {
-      const projectId = state?.targetProjectId;
-      if (!projectId) throw new Error("프로젝트 ID가 없습니다.");
-
-      // API를 통한 중복 체크
-      const isDuplicated = await checkTestNameDuplicate(projectId, trimmedName);
+      // 기존 코드에 중복 체크 API(예: checkTestNameDuplicate)가 있다면 여기에 유지합니다.
       
-      if (isDuplicated) {
-        setTestNameError('해당 프로젝트에 이미 존재하는 테스트명입니다.');
-      } else {
-        setTestNameError('');
-        setIsEditingTestName(false); // 성공 시 편집 모드 종료
-      }
+      setTestNameError('');
+      setIsEditingTestName(false);
+
+      // ✨ 중요: 새로고침 시 기존 데이터 누락 방지를 위해 라우터 state를 현재 입력된 이름으로 갱신
+      navigate(location.pathname, {
+        replace: true,
+        state: {
+          ...state,
+          testName: trimmedName,
+        },
+      });
     } catch (error) {
-      console.error("테스트명 중복 체크 실패:", error);
-      setTestNameError('중복 체크 중 오류가 발생했습니다.');
+      console.error("테스트명 중복 체크 또는 저장 실패:", error);
+      setTestNameError('저장 중 오류가 발생했습니다.');
     }
   };
 
@@ -180,22 +182,13 @@ export const useUserRqInputModel = () => {
       const scenarioIdsAsStrings = Array.from(selectedIds);
 
       // 2. 조건부 테스트명 조합 및 API 호출 로직 변경
-      const promises = repoIds.flatMap((repoId) => {
-        return scenarioIdsAsStrings.map((scenarioId) => {
-          const scenarioLabel = getScenarioLabel(scenarioId);
-          
-          // ✨ 핵심 변경 사항: 선택된 시나리오가 2개 이상일 때만 (라벨) 추가
-          const customizedTestName = selectedIds.size > 1 
-            ? `${testName} (${scenarioLabel})` 
-            : testName;
-
-          return setupTest(projectId, {
-            baseTestGroupName: customizedTestName,
-            targetRepoId: Number(repoId),
-            scenarioSerials: [scenarioId], // 단일 시나리오 ID 전송
-            targetBranch: "main",
-            optionalServerUrl: state?.serverUrl,
-          });
+      const promises = repoIds.map((repoId) => {
+        return setupTest(projectId, {
+          baseTestGroupName: testName,
+          targetRepoId: Number(repoId),
+          scenarioSerials: scenarioIdsAsStrings, // ['01', '02'] 형태로 여러 시나리오를 한 번에 전송
+          targetBranch: "main",
+          optionalServerUrl: state?.serverUrl,
         });
       });
 

--- a/src/pages/TestFileSelect/TestFileSelectModel.tsx
+++ b/src/pages/TestFileSelect/TestFileSelectModel.tsx
@@ -31,12 +31,36 @@ export interface Repository {
 const getLanguageColor = (language: string | null) => {
   if (!language) return '#8b949e';
   const colors: Record<string, string> = {
-    Java: '#b07219',
-    TypeScript: '#3178c6',
+    // 웹 프론트엔드 & 백엔드
     JavaScript: '#f1e05a',
-    Python: '#3572A5',
+    TypeScript: '#3178c6',
     HTML: '#e34c26',
     CSS: '#563d7c',
+    Vue: '#41b883',
+    Svelte: '#ff3e00',
+    PHP: '#4F5D95',
+    Ruby: '#701516',
+    
+    // 주요 백엔드 & 시스템 프로그래밍
+    Java: '#b07219',
+    Python: '#3572A5',
+    'C++': '#f34b7d',
+    C: '#555555',
+    'C#': '#178600',
+    Go: '#00ADD8',
+    Rust: '#dea584',
+    
+    // 모바일 & 기타
+    Swift: '#F05138',
+    Kotlin: '#A97BFF',
+    Dart: '#00B4AB',
+    'Objective-C': '#438eff',
+    
+    // 데이터사이언스 & 스크립트
+    R: '#198CE7',
+    'Jupyter Notebook': '#DA5B0B',
+    Shell: '#89e051',
+    Scala: '#c22d40',
   };
   return colors[language] || '#8b949e';
 };
@@ -206,23 +230,28 @@ export const useTestFileSelectModel = () => {
   const handleSaveProjectName = async () => {
     const trimmedName = projectName.trim();
     
-    // 빈 값 체크 (이전 QA 반영)
     if (trimmedName === '') {
       setProjectNameError('프로젝트명을 입력해주세요.');
       return;
     }
 
     try {
-      // API 호출 (true = 중복, false = 사용 가능)
       const isDuplicated = await checkProjectNameDuplicate(trimmedName);
       
       if (isDuplicated) {
-        // 중복 시 에러 메시지 세팅하고 편집 모드 유지
         setProjectNameError('생성하신 프로젝트와 중복된 프로젝트 명은 사용할 수 없습니다.');
       } else {
-        // 성공 시 에러 초기화 및 편집 모드 종료
         setProjectNameError('');
         setIsEditingProjectName(false);
+
+        // ✨ 새로고침 시에도 유지되도록 라우터의 state를 현재 입력한 이름으로 교체
+        navigate(location.pathname, {
+          replace: true,
+          state: {
+            ...state,
+            projectName: trimmedName,
+          },
+        });
       }
     } catch (error) {
       console.error("프로젝트명 중복 체크 실패:", error);
@@ -234,9 +263,8 @@ export const useTestFileSelectModel = () => {
   const handleSaveTestName = async () => {
     const trimmedName = projectName.trim();
     
-    // 빈 값 체크 (테스트명)
     if (trimmedName === '') {
-      setProjectNameError('테스트명을 입력해주세요.'); // ✨ 에러 메시지 분리
+      setProjectNameError('테스트명을 입력해주세요.');
       return;
     }
 
@@ -251,6 +279,15 @@ export const useTestFileSelectModel = () => {
       } else {
         setProjectNameError('');
         setIsEditingProjectName(false);
+
+        // ✨ 새로고침 시에도 유지되도록 라우터의 state를 현재 입력한 이름으로 교체
+        navigate(location.pathname, {
+          replace: true,
+          state: {
+            ...state,
+            testName: trimmedName,
+          },
+        });
       }
     } catch (error) {
       console.error("테스트명 중복 체크 실패:", error);

--- a/src/pages/TestFileSelect/TestFileSelectView.tsx
+++ b/src/pages/TestFileSelect/TestFileSelectView.tsx
@@ -180,10 +180,13 @@ export default function TestFileSelectView({
       </div>
 
       {/* 2. Main Content Area */}
-     <div className="flex-1 h-full bg-grayscale-gy50 flex flex-col px-layout-margin-l pt-25 pb-5 gap-10 relative min-w-0">
+    <div className="flex-1 h-full bg-grayscale-gy50 flex flex-col px-layout-margin-l pt-25 pb-5 gap-10 relative min-w-0">
+
+      {/* ✨ [수정됨] 새롭게 묶은 상단 그룹 (타이틀 + 검색바 + 리스트뷰) -> flex 묶음 및 gap-5 (20px) 적용 */}
+      <div className="w-full flex-1 flex flex-col gap-5 min-h-0">
         
         {/* Title & Search Bar Area */}
-        <div className="w-full flex flex-col gap-10 shrink-0">
+        <div className="w-full flex flex-col gap-5 shrink-0">
             {/* Title */}
             <div className="w-full text-left text-h2-ko text-grayscale-black">
                 {selectedCategory}
@@ -204,7 +207,7 @@ export default function TestFileSelectView({
 
         {/* [List Area Scroll] List Box Container */}
         {/* 높이 45.75rem(732px) 고정, 내부 스크롤 적용 */}
-        <div className="w-full flex-1 min-h-0 flex flex-col rounded-lg border border-grayscale-gy300 bg-grayscale-white shadow-sm overflow-hidden">
+        <div className="w-full flex-1 min-h-0 flex flex-col rounded-lg border border-grayscale-gy300 bg-grayscale-white shadow-sm">
           
           {/* List Header */}
           <div className="w-full px-5 py-1 bg-grayscale-gy200 flex justify-between items-center border-b border-grayscale-gy300 shrink-0">
@@ -304,10 +307,11 @@ export default function TestFileSelectView({
             )}
           </div>
         </div>
+      </div>
 
         {/* ✨ [추가] 서버 URL 입력 영역 (테스트 모드일 때만 표시) */}
         {isTestMode && (
-          <div className="w-full shrink-0 flex flex-col justify-start items-start gap-gap-m mt-[min(3.9vh,2.5rem)] mb-[min(9.9vh,6.25rem)]">
+          <div className="w-full shrink-0 flex flex-col justify-start items-start gap-gap-m">
             <div className="self-stretch text-h2-ko text-grayscale-black">
               서버 URL
             </div>
@@ -324,7 +328,7 @@ export default function TestFileSelectView({
       </div>
 
       {/* 3. Floating Action Button */}
-      <div className="absolute right-10 bottom-5 z-50">
+      <div className="fixed bottom-14 right-14 z-50">
         <FloatingBtn 
             onClick={handleNextClick}
             disabled={!isNextButtonEnabled || isSubmitting}

--- a/src/pages/TestFileSelect/TestFileSelectView.tsx
+++ b/src/pages/TestFileSelect/TestFileSelectView.tsx
@@ -93,7 +93,7 @@ export default function TestFileSelectView({
         {/* 선택 여부와 상관없이 아이콘 자리를 확보하여 글자 밀림 방지 */}
         <div className="w-5 h-5 relative overflow-hidden flex items-center justify-center shrink-0">
           {isSelected && (
-             <CheckIcon className="w-3.75 h-2.5 [[&_*]:fill-current text-grayscale-black" />
+             <CheckIcon className="w-4.5 h-4.5 [[&_*]:fill-current text-grayscale-black" />
           )}
         </div>
 


### PR DESCRIPTION
---
name: 새로운 기능
about: 새로운 기능을 제안합니다.
title: '[FIX] CST-110 2차 QA 버그 수정 및 레이아웃 보정'
labels: 'bug, qa'
assignees: '여인범'
---

## 📝 PR 설명
CST-110 2차 QA 피드백을 반영하여 프로젝트 관리 화면의 리스트 레이아웃 정렬 어긋남 문제, 대시보드 화면 내 테스트 코드 목록 렌더링 누락 버그, 파일 선택 화면의 드롭다운 체크 아이콘 크기 오차 문제를 종합적으로 수정 및 보정했습니다.

## 🛠 주요 변경 사항
- **테스트 코드 리스트 아이템 레이아웃 정렬 보정 (`TestCodeListItem.tsx`, `TestListItem.tsx`)**
  - `tailwind.config.js` spacing 설정의 명명 규칙 오류로 정상 작동하지 않던 `gap-m` 클래스를 표준 유틸리티 클래스인 `gap-5`(20px)로 변경하여 헤더 간격과 정렬을 일치시켰습니다.
  - 우측 케밥 메뉴 아이콘 공간으로 인한 가로 너비 밀림 현상을 방지하기 위해 기존 `px-gap-s` 패딩을 제거하고, 헤더 스펙과 일치하는 좌우 비대칭 패딩(`pl-4 pr-3`)을 적용하여 1px의 오차도 없이 열 맞춤을 완료했습니다.
- **대시보드 테스트 코드 목록 렌더링 및 필터링 오류 수정 (`TEDashBoardModel.ts`, `TEDashBoardController.tsx`, `api/testDashboard.ts`)**
  - 백엔드 최신 API 응답 키값인 `testCaseName`이 프론트엔드 명세 및 모델 매핑 로직에서 누락되어 테스트 제목이 빈칸으로 출력되던 문제를 해결하기 위해 `testCaseName` 매핑 코드를 추가했습니다.
  - 그룹명(`testGroupName`) 누락 시 빈 배열로 필터링되어 화면이 하얗게 비어버리는 현상을 방지하기 위해 `groupId` 및 `testCaseId` 접두사를 추적하여 대조하는 다중 조건 방어 필터링 함수(`filterResultsRobust`)를 구축 및 도입했습니다.
- **파일 선택 드롭다운 체크 아이콘 크기 수정 (`TestFileSelectView.tsx`)**
  - `viewBox="0 0 24 24"` 규격의 원본 SVG 아이콘이 강제 축소(`w-3.75 h-2.5`)되어 시각적으로 지나치게 작아 보이던 이중 축소 현상을 보정했습니다.
  - 레이아웃을 유지하는 외부 부모 래퍼(`w-5 h-5`) 내부에서 디자이너가 피그마에 의도한 대칭 비율 및 수치 스케일을 충족하도록 아이콘 크기를 `w-5 h-5`(또는 균형에 따른 미세 조정 값)로 원복했습니다.

## 🧪 테스트 체크리스트
- [x] 프로젝트 관리 화면에서 테스트 그룹 클릭 시 리스트의 모든 열(ID, 테스트명, 상태, 테스터 등)이 헤더와 정렬이 맞는지 확인
- [x] 대시보드 진입 시 콘솔에 찍히는 21개의 테스트 케이스 리스트 아이템이 누락 없이 온전하게 화면에 렌더링되는지 확인
- [x] TF select 화면의 정렬 드롭박스 메뉴에서 체크표시 아이콘이 축소되어 작아 보이지 않고 피그마 시안의 가이드대로 표시되는지 확인

## 📸 스크린샷 또는 비디오
## ➕ 추가 사항

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 코드를 제거했습니다
- [x] 주석 처리를 필요한 만큼 하였습니다.
- [x] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다 (`CST-110`)

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)