### PR TITLE
Feature/cst 109 qa2 dh

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/src/assets/logo/Logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>Probe</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/api/project.ts
+++ b/src/api/project.ts
@@ -37,6 +37,20 @@ export const createProject = async (data: CreateProjectRequest): Promise<CreateP
 };
 
 // ==========================================
+// 2-1. 프로젝트 이름 수정 (PATCH)
+// ==========================================
+export interface UpdateProjectNameRequest {
+  projectName: string;
+}
+
+export const updateProjectName = async (
+  projectId: number,
+  data: UpdateProjectNameRequest
+): Promise<void> => {
+  await axiosInstance.patch(`/api/projects/${projectId}/name`, data);
+};
+
+// ==========================================
 // 3. 프로젝트 멤버 초대 (POST)
 // ==========================================
 export interface InviteMembersRequest {

--- a/src/api/testDashboard.ts
+++ b/src/api/testDashboard.ts
@@ -31,6 +31,7 @@ export interface TestDashboardBasicListItem {
   duration?: string | null;
   testDuration?: string | null;
   tester?: string | null;
+  testerProfileImage?: string | null;
   testerName?: string | null;
   completedAt?: string | null;
   executedAt?: string | null;
@@ -55,6 +56,7 @@ export interface ProjectTestSummaryListItem {
   duration?: string | null;
   testDuration?: string | null;
   tester?: string | null;
+  testerProfileImage?: string | null;
   testerName?: string | null;
   completedAt?: string | null;
   executedAt?: string | null;

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -10,6 +10,7 @@ import {
 } from "./styles";
 
 const ICON_TEXT_VARIANTS: IconButtonVariant[] = [
+  "staticWhiteMIconText",
   "dynamicGy900MIconText",
   "dynamicWhiteMDsIconText",
   "dynamicClearSIconText",
@@ -57,9 +58,9 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
       return (
         <button ref={ref} type={type} className={rootClassName} {...btnRest}>
-          {iconPosition === "left" ? <Icon className={iconCls} /> : null}
+          {Icon && iconPosition === "left" ? <Icon className={iconCls} /> : null}
           <span className={labelClassName}>{content}</span>
-          {iconPosition === "right" ? <Icon className={iconCls} /> : null}
+          {Icon && iconPosition === "right" ? <Icon className={iconCls} /> : null}
         </button>
       );
     }

--- a/src/components/common/Button/styles.ts
+++ b/src/components/common/Button/styles.ts
@@ -107,6 +107,16 @@ export const getButtonLabelClassName = (variant: ButtonVariant) => {
 };
 
 // Btn_Dynamic/GY900_M/Icon_Text (반응형)
+const ICONBTN_STATIC_WHITE_M_ICON_TEXT_STATE = {
+  deactive:
+    "disabled:bg-grayscale-white disabled:text-system-deactive disabled:cursor-not-allowed " +
+    "disabled:hover:bg-grayscale-white disabled:active:bg-grayscale-white",
+  default: "bg-grayscale-white text-grayscale-black",
+  hover: "hover:bg-grayscale-gy100 hover:text-grayscale-black",
+  pressing: "active:bg-grayscale-gy200 active:text-grayscale-black",
+  clicked: "focus:outline-none",
+} as const;
+
 const ICONBTN_DYNAMIC_GY900_M_ICON_TEXT_STATE = {
   deactive:
     "disabled:bg-system-deactive disabled:text-grayscale-white disabled:cursor-not-allowed",
@@ -139,6 +149,14 @@ const ICONBTN_DYNAMIC_CLEAR_S_ICON_TEXT_STATE = {
 } as const;
 
 const ICONBUTTON_PRESET: Record<IconButtonVariant, { root: string; label: string }> = {
+  staticWhiteMIconText: {
+    root:
+      "inline-flex items-center justify-start gap-3 rounded-xl px-5 py-3 outline-none " +
+      "aria-[pressed=true]:bg-secondary-sg100 aria-[pressed=true]:text-primary-sg600 " +
+      "aria-[pressed=true]:hover:bg-secondary-sg100 aria-[pressed=true]:hover:text-primary-sg600 " +
+      "aria-[pressed=true]:active:bg-secondary-sg100 aria-[pressed=true]:active:text-primary-sg600",
+    label: "text-h4-ko",
+  },
   dynamicGy900MIconText: {
     root:
       "inline-flex items-center justify-center gap-2 rounded-xl pl-3 pr-4 py-2 outline-none",
@@ -160,6 +178,7 @@ const ICONBUTTON_STATE: Record<
   IconButtonVariant,
   { default: string; hover: string; pressing: string; clicked: string; deactive: string }
 > = {
+  staticWhiteMIconText: ICONBTN_STATIC_WHITE_M_ICON_TEXT_STATE,
   dynamicGy900MIconText: ICONBTN_DYNAMIC_GY900_M_ICON_TEXT_STATE,
   dynamicWhiteMDsIconText: ICONBTN_DYNAMIC_WHITE_M_DS_ICON_TEXT_STATE,
   dynamicClearSIconText: ICONBTN_DYNAMIC_CLEAR_S_ICON_TEXT_STATE,

--- a/src/components/common/Button/types.ts
+++ b/src/components/common/Button/types.ts
@@ -7,6 +7,7 @@ export type ButtonVariant =
   | "dynamicClearSTextUnderlined";
 
 export type IconButtonVariant =
+  | "staticWhiteMIconText"
   | "dynamicGy900MIconText"
   | "dynamicWhiteMDsIconText"
   | "dynamicClearSIconText";

--- a/src/components/common/ListButton/styles.ts
+++ b/src/components/common/ListButton/styles.ts
@@ -145,5 +145,3 @@ export const getListButtonClassNames = (args: {
     ),
   } satisfies ClassNames;
 };
-
-

--- a/src/components/common/ListButton/styles.ts
+++ b/src/components/common/ListButton/styles.ts
@@ -74,6 +74,16 @@ const SELECTED_STATE = {
     clicked: "focus:bg-grayscale-white focus:text-primary-sg600 focus:outline-none",
 } as const;
 
+const SELECTED_STATE_SMOOTH_ICON_TEXT = {
+    deactive:
+    "disabled:bg-grayscale-white disabled:text-system-deactive disabled:cursor-not-allowed " +
+    "disabled:active:bg-grayscale-white",
+    default: "bg-secondary-sg100 text-primary-sg600",
+    hover: "hover:bg-secondary-sg100 hover:text-primary-sg600",
+    pressing: "active:bg-secondary-sg100 active:text-primary-sg600",
+    clicked: "focus:outline-none",
+} as const;
+
 // dynamicWhiteSIconsText는 selected 시에도 텍스트가 블랙
 const SELECTED_STATE_BLACK_TEXT = {
     deactive:
@@ -100,6 +110,8 @@ export const getListButtonClassNames = (args: {
   let stateStyle;
   if (selected && variant === "dynamicWhiteSIconsText") {
     stateStyle = SELECTED_STATE_BLACK_TEXT;
+  } else if (selected && variant === "dynamicWhiteMSmoothIconText") {
+    stateStyle = SELECTED_STATE_SMOOTH_ICON_TEXT;
   } else if (selected) {
     stateStyle = SELECTED_STATE;
   } else {

--- a/src/components/common/ListItem/TestCodeListItem.tsx
+++ b/src/components/common/ListItem/TestCodeListItem.tsx
@@ -8,6 +8,7 @@ export interface TestCodeListItemProps extends React.HTMLAttributes<HTMLDivEleme
   status: StatusBadgeType;
   duration?: string;
   user?: string;
+  testerProfileImage?: string;
   /** 예: "2025-09-09 15:34" (공백으로 날짜/시간 구분) */
   date?: string;
   disabled?: boolean;
@@ -24,6 +25,7 @@ const TestCodeListItem = forwardRef<HTMLDivElement, TestCodeListItemProps>(
       status,
       duration,
       user,
+      testerProfileImage,
       date,
       disabled = false,
       selected,
@@ -112,12 +114,12 @@ const TestCodeListItem = forwardRef<HTMLDivElement, TestCodeListItemProps>(
 
         {/* 5. User */}
         <div className="w-size-min flex items-center justify-start gap-2 overflow-hidden px-2">
-          {!isUntest && (
-            <div className="bg-primary-sg600 relative flex h-6 w-6 flex-shrink-0 items-center justify-center overflow-hidden rounded-full">
-              <span className="text-grayscale-white mt-px text-[10px] leading-none font-bold">
-                U
-              </span>
-            </div>
+          {!isUntest && testerProfileImage && (
+            <img
+              src={testerProfileImage}
+              alt={`${user ?? 'tester'} profile`}
+              className="h-6 w-6 flex-shrink-0 rounded-full object-cover"
+            />
           )}
           <span
             className={`text-medium500-ko line-clamp-1 flex-1 ${subTextColor} ${isUntest ? 'text-center' : 'text-left'}`}

--- a/src/components/common/ListItem/TestListItem.tsx
+++ b/src/components/common/ListItem/TestListItem.tsx
@@ -9,6 +9,7 @@ export interface TestListItemProps extends React.HTMLAttributes<HTMLDivElement> 
   coverage?: string;   
   duration?: string;   
   user?: string;       
+  testerProfileImage?: string;
   date?: string;       
   
   status?: TestItemStatus; 
@@ -26,6 +27,7 @@ const TestListItem = forwardRef<HTMLDivElement, TestListItemProps>(
       coverage,
       duration,
       user,
+      testerProfileImage,
       date,
       status = 'Default',
       disabled = false,
@@ -67,11 +69,6 @@ const TestListItem = forwardRef<HTMLDivElement, TestListItemProps>(
     const subTextColor = disabled || isUntest
       ? "text-system-deactive"
       : "text-grayscale-black";
-
-    // 🎨 User Icon Background
-    const userIconBg = disabled || isUntest
-      ? "bg-system-deactive"
-      : "bg-primary-sg600";
 
     // 메뉴 아이콘 투명도
     const iconOpacity = disabled || isUntest ? "opacity-40" : "opacity-100";
@@ -140,9 +137,13 @@ const TestListItem = forwardRef<HTMLDivElement, TestListItemProps>(
 
         {/* 5. User Column */}
         <div className="w-32 px-gap-xxs flex justify-start items-center gap-2 overflow-hidden">
-            <div className={`w-6 h-6 relative ${userIconBg} rounded-full overflow-hidden flex-shrink-0 flex items-center justify-center`}>
-                <span className="text-[10px] font-bold text-grayscale-white leading-none mt-px">U</span>
-            </div>
+            {!isUntest && testerProfileImage && (
+              <img
+                src={testerProfileImage}
+                alt={`${user ?? "tester"} profile`}
+                className="h-6 w-6 flex-shrink-0 rounded-full object-cover"
+              />
+            )}
             <span className={`flex-1 text-medium-ko line-clamp-1 ${subTextColor}`}>
                 {user || "-"}
             </span>

--- a/src/pages/ProjectManagement/ProjectManagementController.tsx
+++ b/src/pages/ProjectManagement/ProjectManagementController.tsx
@@ -76,8 +76,8 @@ export default function ProjectManagementController() {
       return null;
     }
 
-    const handleSave = (nextName: string, nextMembers: Member[]) => {
-      model.saveSettings(id, nextName, nextMembers);
+    const handleSave = async (nextName: string, nextMembers: Member[]) => {
+      await model.saveSettings(id, nextName, nextMembers);
     };
     const handleLeaveProject = async () => {
       await model.leaveOrDeleteProject(id);

--- a/src/pages/ProjectManagement/ProjectManagementModel.ts
+++ b/src/pages/ProjectManagement/ProjectManagementModel.ts
@@ -14,6 +14,7 @@ import {
   fetchProjectMembers,
   fetchProjectRepos,
   fetchProjects,
+  inviteMembers,
   leaveProjectAsMember,
   updateProjectName,
 } from "../../api/project";
@@ -534,6 +535,14 @@ export default function useProjectManagementModel() {
 
     if (detail && detail.name !== nextName) {
       await updateProjectName(numericProjectId, { projectName: nextName });
+    }
+
+    const memberEmails = nextMembers
+      .map((member) => member.email)
+      .filter((email): email is string => Boolean(email?.trim()));
+
+    if (memberEmails.length > 0) {
+      await inviteMembers(numericProjectId, { emails: memberEmails });
     }
 
     setProjects((prev) =>

--- a/src/pages/ProjectManagement/ProjectManagementModel.ts
+++ b/src/pages/ProjectManagement/ProjectManagementModel.ts
@@ -15,6 +15,7 @@ import {
   fetchProjectRepos,
   fetchProjects,
   leaveProjectAsMember,
+  updateProjectName,
 } from "../../api/project";
 import type {
   ProjectDailyAvgTestStatsItem,
@@ -524,7 +525,17 @@ export default function useProjectManagementModel() {
     });
   };
 
-  const saveSettings = (projectId: string, nextName: string, nextMembers: Member[]) => {
+  const saveSettings = async (projectId: string, nextName: string, nextMembers: Member[]) => {
+    const detail = detailsById[projectId];
+    const numericProjectId = Number(projectId);
+    if (!Number.isFinite(numericProjectId)) {
+      throw new Error(`유효하지 않은 프로젝트 ID입니다: ${projectId}`);
+    }
+
+    if (detail && detail.name !== nextName) {
+      await updateProjectName(numericProjectId, { projectName: nextName });
+    }
+
     setProjects((prev) =>
       prev.map((p) => (p.id === projectId ? { ...p, name: nextName } : p))
     );

--- a/src/pages/ProjectManagement/ProjectManagementModel.ts
+++ b/src/pages/ProjectManagement/ProjectManagementModel.ts
@@ -198,6 +198,7 @@ const mapProjectTest = (
     passRatio: toOptionalText(test.passRatio),
     duration: toOptionalText(test.duration) ?? toOptionalText(test.testDuration),
     user: toOptionalText(test.tester) ?? toOptionalText(test.testerName),
+    testerProfileImage: toOptionalText(test.testerProfileImage),
     date: formatCompletedAt(test.completedAt ?? test.executedAt ?? test.createdAt),
   };
 };

--- a/src/pages/ProjectManagement/components/MemberSearch.tsx
+++ b/src/pages/ProjectManagement/components/MemberSearch.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ChangeEvent } from "react";
 import type { Member } from "../types";
 import MemberChip from "./MemberChip";
 
 import InputField from "../../../components/common/InputField";
 import { ListButton } from "../../../components/common/ListButton";
+import { searchUsers } from "../../../api/project";
 
 type Props = {
   allCandidates: Member[];
@@ -22,18 +23,54 @@ export default function MemberSearch({
   onChangeSelected,
 }: Props) {
   const [q, setQ] = useState("");
+  const [apiResults, setApiResults] = useState<Member[]>([]);
 
   const query = q.trim().toLowerCase();
   const isSearching = query.length > 0;
 
+  useEffect(() => {
+    if (!query) {
+      setApiResults([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    const timer = window.setTimeout(async () => {
+      try {
+        const results = await searchUsers(query);
+        if (cancelled) return;
+
+        setApiResults(
+          results.map((user) => ({
+            id: String(user.userId),
+            username: user.username,
+            email: user.email,
+            profileImageUrl: user.profileImageUrl,
+          }))
+        );
+      } catch (error) {
+        console.error("[ProjectManagement] 멤버 검색 실패:", error);
+        if (!cancelled) setApiResults([]);
+      }
+    }, 300);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [query]);
+
   const searchResults = useMemo(() => {
     if (!query) return [];
 
-    return allCandidates
+    const source = apiResults.length > 0 ? apiResults : allCandidates;
+
+    return source
       .filter((m) => m.username.toLowerCase().includes(query))
       .filter((m) => !selected.some((s) => s.id === m.id))
       .slice(0, 8);
-  }, [query, allCandidates, selected]);
+  }, [query, apiResults, allCandidates, selected]);
 
   const add = (m: Member) => {
     onChangeSelected([...selected, m]);
@@ -66,7 +103,9 @@ export default function MemberSearch({
                 label={m.username}
                 leading={{
                   type: "avatar",
-                  fallbackText: m.username.charAt(0).toUpperCase(),}}
+                  src: m.profileImageUrl,
+                  fallbackText: m.username.charAt(0).toUpperCase(),
+                }}
                 trailing={{ type: "none" }}
                 onClick={() => add(m)}
                 className="self-stretch"

--- a/src/pages/ProjectManagement/components/ProjectTestRow.tsx
+++ b/src/pages/ProjectManagement/components/ProjectTestRow.tsx
@@ -17,6 +17,7 @@ export default function ProjectTestRow({ item, onOpenDashboard, onOpenRowMenu }:
       coverage={item.passRatio}
       duration={item.duration}
       user={item.user}
+      testerProfileImage={item.testerProfileImage}
       date={item.date}
       status="Default"
       selected={false}

--- a/src/pages/TA/UserRqInputView.tsx
+++ b/src/pages/TA/UserRqInputView.tsx
@@ -1,7 +1,6 @@
 // src/pages/Home/TA/UserRqInputView.tsx
 import type { ScenarioCategory } from "./UserRqInputModel";
 import FloatingBtn from "../../components/common/FloatingBtn";
-import SelectTrigger from "../../components/common/TriggerButton/SelectTrigger";
 import TestDownloadModal from "../../components/common/Modal/TestDownloadModal";
 import TestCompleteModal from "../../components/common/Modal/TestCompleteModal";
 import type { TestProcessStage } from "./UserRqInputModel";
@@ -154,16 +153,17 @@ export default function UserRqInputView({
                 {category.items.map((item) => {
                   const isSelected = selectedIds.has(item.id);
                   return (
-                    <SelectTrigger
+                    <Button
                       key={item.id}
-                      label={item.label}
-                      variant="dynamic"
-                      selected={isSelected} // 추가됨
-                      onClick={() => toggleScenario(item.id)}
-                      // 색상 조건문 삭제, 기본 형태만 유지
-                      className="px-5 py-3 rounded-xl" 
+                      variant="staticWhiteMIconText"
+                      iconPosition="left"
                       iconClassName="hidden"
-                    />
+                      aria-pressed={isSelected}
+                      onClick={() => toggleScenario(item.id)}
+                      className="w-full"
+                    >
+                      {item.label}
+                    </Button>
                   );
                 })}
               </div>

--- a/src/pages/TEDashBoard/TEDashBoardModel.ts
+++ b/src/pages/TEDashBoard/TEDashBoardModel.ts
@@ -71,6 +71,7 @@ const mapResultToTestCodeItem = (
     passRatio: toOptionalText(result.passRatio),
     duration: toOptionalText(result.duration) ?? toOptionalText(result.testDuration),
     user: toOptionalText(result.tester) ?? toOptionalText(result.testerName),
+    testerProfileImage: toOptionalText(result.testerProfileImage),
     date: formatDate(result.completedAt ?? result.executedAt ?? result.createdAt),
   };
 };

--- a/src/pages/TEDashBoard/components/DetailSection.tsx
+++ b/src/pages/TEDashBoard/components/DetailSection.tsx
@@ -101,13 +101,14 @@ export default function DetailSection({ projectId, item, onClose }: Props) {
     if (isFail) {
       return [
         { value: "result", label: "결과" },
-        { value: "failCode", label: "Fail 테스트 코드" },
+        { value: "failCode", label: "테스트 코드" },
         { value: "scenario", label: "테스트 시나리오" },
         { value: "proof", label: "증명" },
       ];
     }
     return [
       { value: "result", label: "결과" },
+      { value: "failCode", label: "테스트 코드" },
       { value: "scenario", label: "테스트 시나리오" },
       { value: "proof", label: "증명" },
     ];
@@ -207,13 +208,11 @@ export default function DetailSection({ projectId, item, onClose }: Props) {
   }, [visualDetail]);
 
   const resultContentRaw = stripAnsi(basicDetail?.errorLog) ?? basicDetail?.result;
-  const failCodeContentRaw = codeDetail?.testCode ?? codeDetail?.failTestCode;
+  const testCodeContentRaw = codeDetail?.testCode ?? codeDetail?.failTestCode;
   const resultContent = toText(resultContentRaw);
-  const failCodeContent = toText(failCodeContentRaw);
-  const showOutputBox =
-    isFail &&
-    ((tab === "result" && hasText(resultContentRaw)) ||
-      (tab === "failCode" && hasText(failCodeContentRaw)));
+  const testCodeContent = toText(testCodeContentRaw);
+  const showResultBox = tab === "result" && isFail && hasText(resultContentRaw);
+  const showTestCodeBox = tab === "failCode";
 
   return (
     <aside className="w-layout-split self-stretch bg-grayscale-gy50 shadow-[inset_0px_0px_32px_0px_rgba(31,35,40,0.10)] inline-flex flex-col justify-start items-start px-layout-margin py-8 gap-10 ">
@@ -275,12 +274,17 @@ export default function DetailSection({ projectId, item, onClose }: Props) {
             </div>
           </div>
           
-          {showOutputBox && (
+          {showResultBox && (
             <OutputBox
-              title={tab === "result" ? "Error Message" : "Fail Test Code"}
-              content={
-                tab === "result" ? resultContent : failCodeContent
-              }
+              title="Error Message"
+              content={resultContent}
+            />
+          )}
+
+          {showTestCodeBox && (
+            <OutputBox
+              title="Test Code"
+              content={testCodeContent}
             />
           )}
 

--- a/src/pages/TEDashBoard/components/HeaderFrame.tsx
+++ b/src/pages/TEDashBoard/components/HeaderFrame.tsx
@@ -42,7 +42,7 @@ export default function HeaderFrame({
       ) : (
         <div className="max-w-m flex w-full items-center gap-3">
           <div className="min-w-0 flex-1">
-            <InputField value={draftTitle} onChange={(e) => setDraftTitle(e.target.value)} />
+            <InputField value={draftTitle} onChange={(e) => setDraftTitle(e.target.value)} showIcon={false} />
           </div>
 
           <Button

--- a/src/pages/TEDashBoard/components/HeaderFrame.tsx
+++ b/src/pages/TEDashBoard/components/HeaderFrame.tsx
@@ -42,7 +42,7 @@ export default function HeaderFrame({
       ) : (
         <div className="max-w-m flex w-full items-center gap-3">
           <div className="min-w-0 flex-1">
-            <InputField value={draftTitle} onChange={(e) => setDraftTitle(e.target.value)} showIcon={false} />
+            <InputField value={draftTitle} onChange={(e) => setDraftTitle(e.target.value)} showIcon={false}/>
           </div>
 
           <Button

--- a/src/pages/TEDashBoard/components/TestCodeSection.tsx
+++ b/src/pages/TEDashBoard/components/TestCodeSection.tsx
@@ -128,6 +128,7 @@ export default function TestCodeSection({
                   status={statusType}
                   duration={it.duration}
                   user={it.user}
+                  testerProfileImage={it.testerProfileImage}
                   date={it.date}
                   selected={isSelected}
                   onSelectChange={handleSelectChange}

--- a/src/pages/TEDashBoard/types.ts
+++ b/src/pages/TEDashBoard/types.ts
@@ -14,6 +14,7 @@ export type TestCodeItem = {
   passRatio?: string;
   duration?: string;
   user?: string;
+  testerProfileImage?: string;
   date?: string;
 };
 

--- a/src/pages/TestFileSelect/TestFileSelectView.tsx
+++ b/src/pages/TestFileSelect/TestFileSelectView.tsx
@@ -1,7 +1,7 @@
 import type { useTestFileSelectModel } from './TestFileSelectModel';
 
 // Components
-import { DynamicWhiteMIconTextButton } from '../../components/common/ListButton/ListButton';
+import { DynamicWhiteMSmoothIconTextButton } from '../../components/common/ListButton/ListButton';
 import InputField from '../../components/common/InputField';
 import RepositoryListItem from '../../components/common/ListItem/RepositoryListItem';
 import FloatingBtn from '../../components/common/FloatingBtn';
@@ -165,7 +165,7 @@ export default function TestFileSelectView({
           {CATEGORIES.map((category) => {
             const isSelected = selectedCategory === category.label;
             return (
-              <DynamicWhiteMIconTextButton
+              <DynamicWhiteMSmoothIconTextButton
                 key={category.label}
                 label={category.label}
                 leading={{ type: 'icon', icon: 'plus' }}


### PR DESCRIPTION
---
name: 새로운 기능
about: 새로운 기능을 제안합니다.
title: '[FEATURE] CST-109 QA2 UI/API 연결 및 버튼 상태 개선'
labels: feature
assignees: ''
---

## 📝 PR 설명
QA2 작업 범위에서 ProjectManagement, TEDashboard, TA/TestFileSelect 화면의 API 연동 및 UI 상태 처리를 개선했습니다.  
프로필 이미지, 프로젝트 멤버 조회/검색/초대, 프로젝트명 수정 API를 연결하고, 버튼 선택 상태가 포커스가 아닌 실제 선택값 기준으로 유지되도록 수정했습니다.

## 🛠 주요 변경 사항
- ProjectManagement 프로젝트 설정에서 멤버 조회, 사용자 검색, 멤버 초대, 프로젝트명 수정 API를 연결했습니다.
- TEDashboard/TestList/TestCodeList에 `testerProfileImage`를 반영하고, 테스트 상세 영역의 결과/테스트 코드 UI를 정리했습니다.
- TA 시나리오 버튼 및 TestFileSelect 사이드바 버튼을 디자인 시스템 Button/ListButton variant 기준으로 교체하고 선택 상태 유지 방식을 수정했습니다.
- favicon 및 페이지 타이틀을 임시 반영했습니다.

## 🧪 테스트 체크리스트
- [x] `npm run -s build` 성공 확인
- [ ] ProjectManagement 설정 화면에서 멤버 목록이 정상 조회되는지 확인
- [ ] ProjectManagement 설정 화면에서 멤버 검색 및 추가가 정상 동작하는지 확인
- [ ] ProjectManagement 설정 화면에서 프로젝트명 수정 후 저장되는지 확인
- [ ] TEDashboard 테스트 리스트에서 프로필 이미지가 정상 표시되는지 확인
- [ ] TEDashboard 상세 패널에서 결과/테스트 코드 탭 UI가 정상 표시되는지 확인
- [ ] TA 시나리오 버튼 선택/해제 시 색상 상태가 즉시 반영되는지 확인
- [ ] TestFileSelect 사이드바 All/Public/Private 선택 상태가 다른 곳 클릭 후에도 유지되는지 확인

## 📸 스크린샷 또는 비디오
<!-- UI 변경사항 확인 후 스크린샷 첨부 예정 -->

<img width="1209" height="516" alt="image" src="https://github.com/user-attachments/assets/8fd5f43c-0d5f-492e-9f23-5ae05934c209" />


## ➕ 추가 사항
- 버튼 selected 상태가 `focus`에 의존하지 않도록 수정했습니다.
- 백엔드 응답에 `testerProfileImage`가 포함되는 기준으로 화면 표시를 반영했습니다.

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 코드를 제거했습니다
- [x] 주석 처리를 필요한 만큼 하였습니다.
- [x] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)