### PR TITLE
Feature/cst 109 qa2 dh

### DIFF
--- a/src/api/testDashboard.ts
+++ b/src/api/testDashboard.ts
@@ -25,6 +25,7 @@ export interface TestDashboardBasicListItem {
   executionId?: IdParam | null;
   testCaseName?: string | null;
   testCodeName?: string | null;
+  CaseName?: string | null;
   testGroupName?: string | null;
   status?: string | null;
   passRatio?: string | null;
@@ -50,6 +51,7 @@ export interface ProjectTestSummaryListItem {
   executionId?: IdParam | null;
   testCaseName?: string | null;
   testCodeName?: string | null;
+  CaseName?: string | null;
   testGroupName?: string | null;
   status?: string | null;
   passRatio: string | null;
@@ -91,7 +93,7 @@ export interface UpdateTestDashboardGroupNameRequest {
 }
 
 export interface UpdateTestDashboardCodeNameRequest {
-  newTestCodeName: string;
+  CaseName: string;
 }
 
 export interface TestDashboardResultFullViewResponse {
@@ -218,9 +220,9 @@ export const updateTestDashboardGroupName = async (
 export const updateTestDashboardCodeName = async (
   projectId: IdParam,
   resultId: IdParam,
-  newTestCodeName: string
+  CaseName: string
 ): Promise<void> => {
-  const body: UpdateTestDashboardCodeNameRequest = { newTestCodeName };
+  const body: UpdateTestDashboardCodeNameRequest = { CaseName };
   await axiosInstance.patch(`/api/projects/${projectId}/tests/results/${resultId}/name`, body);
 };
 

--- a/src/components/common/ListItem/TestCodeListItem.tsx
+++ b/src/components/common/ListItem/TestCodeListItem.tsx
@@ -87,7 +87,7 @@ const TestCodeListItem = forwardRef<HTMLDivElement, TestCodeListItemProps>(
             onClick?.(e);
           }
         }}
-        className={`group gap-5 pl-4 pr-3 py-4 border-grayscale-gy300 bg-grayscale-white relative inline-flex w-full items-center border-b transition-colors duration-200 ${!disabled && 'hover:bg-grayscale-gy100 active:bg-grayscale-gy200'} ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'} ${className || ''} `}
+        className={`group relative inline-flex w-full items-center gap-5 border-b border-grayscale-gy300 bg-grayscale-white p-4 transition-colors duration-200 ${!disabled && 'hover:bg-grayscale-gy100 active:bg-grayscale-gy200'} ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'} ${className || ''} `}
         {...rest}
       >
         {/* 1. ID */}

--- a/src/components/common/TriggerButton/styles.ts
+++ b/src/components/common/TriggerButton/styles.ts
@@ -9,7 +9,7 @@ const STATE_ROOT_COMMON = {
   default: "text-grayscale-black",
   hover: "hover:bg-[rgba(31,35,40,0.05)] hover:text-grayscale-black",
   pressing: "active:bg-[rgba(31,35,40,0.10)]",
-  clicked: "focus:bg-grayscale-white focus:text-grayscale-black",
+  clicked: "focus:bg-transparent focus:text-grayscale-black",
 } as const;
 
 const PRESET: Record<SelectTriggerVariant, { root: string; label: string }> = {

--- a/src/pages/ProjectManagement/ProjectManagementController.tsx
+++ b/src/pages/ProjectManagement/ProjectManagementController.tsx
@@ -14,7 +14,7 @@ export default function ProjectManagementController() {
   const goSettings = (projectId: string) => nav(`/project-management/${projectId}/settings`);
   const goTestDashboard = (projectId: string, test: TestCodeItem) => {
     const groupId = test.groupId;
-    const executionId = test.executionId ?? groupId;
+    const executionId = test.executionId;
     const testCaseId = test.id || test.codeId;
     const params = new URLSearchParams({ projectId });
 

--- a/src/pages/ProjectManagement/ProjectManagementModel.ts
+++ b/src/pages/ProjectManagement/ProjectManagementModel.ts
@@ -151,6 +151,45 @@ const formatCodeId = (id: string): string => {
   return `${parts[0]}_${parts[2]}`;
 };
 
+const SCENARIO_GUIDE_NAMES: Record<string, string> = {
+  "01": "회원가입",
+  "02": "로그인",
+  "03": "비밀번호 찾기/재설정",
+  "04": "로그아웃",
+  "05": "프로필 수정",
+  "06": "비밀번호 변경",
+  "07": "권한 기반 접근 제어",
+  "08": "세션 만료/토큰 만료",
+  "09": "게시글 작성",
+  "10": "게시글 수정/삭제",
+  "11": "댓글 작성/수정/삭제",
+  "12": "좋아요/즐겨찾기",
+  "13": "검색",
+  "14": "필터/정렬",
+  "15": "반응형 레이아웃",
+  "16": "브라우저 호환성",
+  "17": "에러 페이지 동작",
+  "18": "네트워크 끊김 상태",
+  "19": "서버 응답 지연",
+  "20": "API 에러 응답 처리",
+  "21": "A/B 테스트 요소 확인",
+  "22": "입력값 유효성 검사",
+  "23": "다국어 지원 시 언어 변경 테스트",
+  "24": "파일 업로드/다운로드",
+  "25": "푸시 알림",
+  "26": "다중 사용자 동시 접속",
+};
+
+const getScenarioSerial = (testCaseId: string | number | null | undefined): string | undefined => {
+  const text = String(testCaseId ?? "").trim();
+  return /^T(\d{2})/.exec(text)?.[1];
+};
+
+const getScenarioGuideName = (test: TestDashboardBasicListItem): string | undefined => {
+  const serial = getScenarioSerial(test.testCaseId);
+  return serial ? SCENARIO_GUIDE_NAMES[serial] : undefined;
+};
+
 type ProjectTestNameSource = Pick<
   TestDashboardBasicListItem,
   "testCaseName" | "testCodeName" | "testGroupName"
@@ -161,10 +200,19 @@ const getProjectTestName = (test: ProjectTestNameSource): string | undefined =>
   toOptionalText(test.testCodeName) ??
   toOptionalText(test.testCaseName);
 
-const getProjectTestGroupKey = (test: TestDashboardBasicListItem, index: number): string =>
-  getProjectTestName(test) ??
-  toOptionalText(test.testCaseId) ??
-  `test-${index + 1}`;
+const getProjectTestGroupKey = (test: TestDashboardBasicListItem, index: number): string => {
+  const groupId = toOptionalIdText(test.groupId ?? test.testGroupId);
+  const scenarioSerial = getScenarioSerial(test.testCaseId);
+
+  return (
+    toOptionalIdText(test.executionId) ??
+    (groupId && scenarioSerial ? `${groupId}:${scenarioSerial}` : undefined) ??
+    groupId ??
+    getProjectTestName(test) ??
+    toOptionalText(test.testCaseId) ??
+    `test-${index + 1}`
+  );
+};
 
 const getUniqueProjectTestGroups = (
   tests: TestDashboardBasicListItem[]
@@ -179,13 +227,54 @@ const getUniqueProjectTestGroups = (
   });
 };
 
+const getScenarioSuffixKey = (test: TestDashboardBasicListItem): string | undefined => {
+  const title = getProjectTestName(test);
+  if (!title) return undefined;
+
+  const groupKey = toOptionalIdText(test.groupId ?? test.testGroupId) ?? title;
+  return `${groupKey}:${title}`;
+};
+
+const getScenarioSuffixKeys = (tests: TestDashboardBasicListItem[]): Set<string> => {
+  const scenarioNamesByTitle = new Map<string, Set<string>>();
+
+  tests.forEach((test) => {
+    const key = getScenarioSuffixKey(test);
+    const scenarioGuideName = getScenarioGuideName(test);
+    if (!key || !scenarioGuideName) return;
+
+    const names = scenarioNamesByTitle.get(key) ?? new Set<string>();
+    names.add(scenarioGuideName);
+    scenarioNamesByTitle.set(key, names);
+  });
+
+  return new Set(
+    Array.from(scenarioNamesByTitle.entries())
+      .filter(([, names]) => names.size > 1)
+      .map(([key]) => key)
+  );
+};
+
+const buildProjectTestTitle = (
+  test: TestDashboardBasicListItem,
+  shouldAppendScenarioGuideName: boolean
+): string => {
+  const title = getProjectTestName(test) ?? "";
+  const scenarioGuideName = getScenarioGuideName(test);
+  if (!shouldAppendScenarioGuideName || !title || !scenarioGuideName) return title;
+  if (title.endsWith(`(${scenarioGuideName})`)) return title;
+
+  return `${title} (${scenarioGuideName})`;
+};
+
 const mapProjectTest = (
   projectId: number,
   test: TestDashboardBasicListItem,
-  index: number
+  index: number,
+  titleOverride?: string
 ): TestCodeItem => {
   const id = toOptionalText(test.testCaseId) ?? toOptionalText(test.id);
-  const title = getProjectTestName(test) ?? '';
+  const title = titleOverride ?? getProjectTestName(test) ?? '';
   const key = id ?? `${index}`;
   const groupId = toNumericIdText(test.groupId ?? test.testGroupId);
 
@@ -203,6 +292,23 @@ const mapProjectTest = (
     testerProfileImage: toOptionalText(test.testerProfileImage),
     date: formatCompletedAt(test.completedAt ?? test.executedAt ?? test.createdAt),
   };
+};
+
+const mapProjectTests = (
+  projectId: number,
+  tests: TestDashboardBasicListItem[]
+): TestCodeItem[] => {
+  const uniqueTests = getUniqueProjectTestGroups(tests);
+  const scenarioSuffixKeys = getScenarioSuffixKeys(uniqueTests);
+
+  return uniqueTests.map((test, index) =>
+    mapProjectTest(
+      projectId,
+      test,
+      index,
+      buildProjectTestTitle(test, scenarioSuffixKeys.has(getScenarioSuffixKey(test) ?? ""))
+    )
+  );
 };
 
 const formatTestedText = (
@@ -370,9 +476,7 @@ const resolveProjectMetadata = async (
       fetchProjectGlobalTestStats(project.id),
       fetchProjectDailyAvgTestStats(project.id),
     ]);
-    tests = getUniqueProjectTestGroups(testResponses).map((test, index) =>
-      mapProjectTest(project.id, test, index)
-    );
+    tests = mapProjectTests(project.id, testResponses);
     const {
       passCount,
       totalCount: testTotalCount,

--- a/src/pages/ProjectManagement/ProjectManagementModel.ts
+++ b/src/pages/ProjectManagement/ProjectManagementModel.ts
@@ -27,7 +27,7 @@ import {
   fetchProjectDailyAvgTestStats,
   fetchProjectGlobalTestStats,
   fetchTestDashboardBasicList,
-  updateTestDashboardGroupName,
+  updateTestDashboardCodeName,
 } from "../../api/testDashboard";
 import { fetchUserMe } from "../../api/user";
 
@@ -192,10 +192,11 @@ const getScenarioGuideName = (test: TestDashboardBasicListItem): string | undefi
 
 type ProjectTestNameSource = Pick<
   TestDashboardBasicListItem,
-  "testCaseName" | "testCodeName" | "testGroupName"
+  "CaseName" | "testCaseName" | "testCodeName" | "testGroupName"
 >;
 
 const getProjectTestName = (test: ProjectTestNameSource): string | undefined =>
+  toOptionalText(test.CaseName) ??
   toOptionalText(test.testGroupName) ??
   toOptionalText(test.testCodeName) ??
   toOptionalText(test.testCaseName);
@@ -283,6 +284,7 @@ const mapProjectTest = (
     codeId: id ? formatCodeId(id) : '',
     title,
     status: normalizeStatus(test.status),
+    resultId: toNumericIdText(test.resultId ?? test.testResultId ?? test.id),
     projectId: String(projectId),
     groupId,
     executionId: toOptionalIdText(test.executionId),
@@ -663,16 +665,16 @@ export default function useProjectManagementModel() {
   const renameTestGroup = async (projectId: string, testId: string, nextTitle: string) => {
     const detail = detailsById[projectId];
     const target = detail?.tests.find((test) => test.id === testId);
-    const groupId = target?.groupId;
+    const resultId = target?.resultId;
 
-    if (!detail || !target || !groupId) {
+    if (!detail || !target || !resultId) {
       const message =
-        "[ProjectManagement] 테스트 그룹명 수정에 필요한 숫자 groupId가 없습니다. /tests/list/basic 응답에 groupId를 내려줘야 합니다.";
+        "[ProjectManagement] 테스트명 수정에 필요한 숫자 resultId가 없습니다. /tests/list/basic 응답에 resultId를 내려줘야 합니다.";
       console.error(message, { projectId, testId, target });
       throw new Error(message);
     }
 
-    await updateTestDashboardGroupName(projectId, groupId, nextTitle);
+    await updateTestDashboardCodeName(projectId, resultId, nextTitle);
     setDetailsById((prev) => {
       const cur = prev[projectId];
       if (!cur) return prev;

--- a/src/pages/TA/UserRqInputController.tsx
+++ b/src/pages/TA/UserRqInputController.tsx
@@ -1,6 +1,7 @@
 import { useUserRqInputModel } from './UserRqInputModel';
 import UserRqInputView from './UserRqInputView';
 import { useNavigate } from 'react-router-dom';
+import { fetchTestDashboardBasicList } from '../../api/testDashboard';
 
 export default function UserRqInputController() {
   const model = useUserRqInputModel();
@@ -23,16 +24,38 @@ export default function UserRqInputController() {
 //   };
 
   // '대시보드로 이동' 버튼 클릭 시
-  const handleGoToDashboard = () => {
+  const handleGoToDashboard = async () => {
     console.log('대시보드로 이동');
     model.setIsTestProcessModalOpen(false);
 
     if (model.targetProjectId && model.dashboardGroupId) {
+      const projectId = String(model.targetProjectId);
+      const executionId = String(model.dashboardGroupId);
+      let groupId = executionId;
+      let groupName: string | undefined;
+      let testCaseId: string | undefined;
+
+      try {
+        const tests = await fetchTestDashboardBasicList(projectId);
+        const target =
+          tests.find((test) => String(test.executionId ?? '') === executionId) ??
+          tests.find((test) => String(test.groupId ?? test.testGroupId ?? '') === executionId);
+        const resolvedGroupId = target?.groupId ?? target?.testGroupId;
+
+        if (resolvedGroupId) groupId = String(resolvedGroupId);
+        if (target?.testGroupName) groupName = target.testGroupName;
+        if (target?.testCaseId) testCaseId = target.testCaseId;
+      } catch (error) {
+        console.error('[UserRqInput] 대시보드 식별자 조회 실패:', error);
+      }
+
       const params = new URLSearchParams({
-        projectId: String(model.targetProjectId),
-        groupId: String(model.dashboardGroupId),
-        executionId: String(model.dashboardGroupId),
+        projectId,
+        groupId,
+        executionId,
       });
+      if (groupName) params.set('groupName', groupName);
+      if (testCaseId) params.set('testCaseId', testCaseId);
       navigate(`/test-dashboard?${params.toString()}`);
       return;
     }

--- a/src/pages/TA/UserRqInputController.tsx
+++ b/src/pages/TA/UserRqInputController.tsx
@@ -31,6 +31,7 @@ export default function UserRqInputController() {
     if (model.targetProjectId && model.dashboardGroupId) {
       const projectId = String(model.targetProjectId);
       const executionId = String(model.dashboardGroupId);
+      const shouldFilterSingleScenario = model.selectedIds.size === 1;
       let groupId = executionId;
       let groupName: string | undefined;
       let testCaseId: string | undefined;
@@ -43,8 +44,8 @@ export default function UserRqInputController() {
         const resolvedGroupId = target?.groupId ?? target?.testGroupId;
 
         if (resolvedGroupId) groupId = String(resolvedGroupId);
-        if (target?.testGroupName) groupName = target.testGroupName;
-        if (target?.testCaseId) testCaseId = target.testCaseId;
+        if (shouldFilterSingleScenario && target?.testGroupName) groupName = target.testGroupName;
+        if (shouldFilterSingleScenario && target?.testCaseId) testCaseId = target.testCaseId;
       } catch (error) {
         console.error('[UserRqInput] 대시보드 식별자 조회 실패:', error);
       }

--- a/src/pages/TEDashBoard/TEDashBoardController.tsx
+++ b/src/pages/TEDashBoard/TEDashBoardController.tsx
@@ -78,7 +78,6 @@ const filterDashboardResults = (
 };
 
 type DashboardBasicIds = {
-  testCaseId?: string | number;
   executionId?: string | number;
 };
 
@@ -95,7 +94,6 @@ const resolveDashboardBasicIdsByGroupId = async (
   }) ?? tests[0];
 
   return {
-    testCaseId: toParam(target?.testCaseId),
     executionId: toParam(target?.executionId),
   };
 };
@@ -228,7 +226,7 @@ export default function TEDashBoardController() {
 
         const isSameAsGroupId = String(executionId ?? '') === String(groupId ?? '');
         const resolvedBasicIds: DashboardBasicIds =
-          !executionId || !testCaseId || isSameAsGroupId
+          !executionId || isSameAsGroupId
             ? await resolveDashboardBasicIdsByGroupId(projectId, groupId).catch((error) => {
                 console.error('[TEDashBoard] 테스트 기본 식별자 조회 실패:', error);
                 return {};
@@ -258,13 +256,14 @@ export default function TEDashBoardController() {
         ]);
         if (cancelled) return;
 
-        const resolvedTestCaseId = testCaseId ?? resolvedBasicIds.testCaseId;
+        const resolvedTestCaseId = testCaseId;
         setResolvedExecutionId(statsExecutionId);
+        const displayGroup = groupName ? { ...group, groupName: String(groupName) } : group;
 
         setData(
           getTEDashBoardData({
-            group,
-            results: filterDashboardResults(results, group.groupName, resolvedTestCaseId),
+            group: displayGroup,
+            results: filterDashboardResults(results, displayGroup.groupName, resolvedTestCaseId),
             stats,
           })
         );

--- a/src/pages/TEDashBoard/TEDashBoardController.tsx
+++ b/src/pages/TEDashBoard/TEDashBoardController.tsx
@@ -77,19 +77,27 @@ const filterDashboardResults = (
   return filterResultsByGroupName(results, String(groupName ?? ''));
 };
 
-const resolveTestCaseIdByGroupId = async (
+type DashboardBasicIds = {
+  testCaseId?: string | number;
+  executionId?: string | number;
+};
+
+const resolveDashboardBasicIdsByGroupId = async (
   projectId: string | number,
   groupId?: string | number
-): Promise<string | undefined> => {
-  if (!groupId) return undefined;
+): Promise<DashboardBasicIds> => {
+  if (!groupId) return {};
 
-  const tests = await fetchTestDashboardBasicList(projectId);
+  const tests = await fetchTestDashboardBasicList(projectId, groupId);
   const target = tests.find((test) => {
     const testGroupId = test.groupId ?? test.testGroupId;
     return String(testGroupId ?? '') === String(groupId);
-  });
+  }) ?? tests[0];
 
-  return target?.testCaseId ?? undefined;
+  return {
+    testCaseId: toParam(target?.testCaseId),
+    executionId: toParam(target?.executionId),
+  };
 };
 
 type TEDashBoardContentProps = {
@@ -167,20 +175,18 @@ export default function TEDashBoardController() {
         toParam(searchParams.get('codeId')),
       executionId:
         toParam(routeState.executionId) ??
-        toParam(searchParams.get('executionId')) ??
-        toParam(routeState.groupId) ??
-        toParam(routeState.testGroupId) ??
-        toParam(searchParams.get('groupId')) ??
-        toParam(searchParams.get('testGroupId')),
+        toParam(searchParams.get('executionId')),
     };
   }, [location.search, location.state]);
 
   const [data, setData] = useState<TEDashBoardData>(() => getTEDashBoardData());
+  const [resolvedExecutionId, setResolvedExecutionId] = useState<string | number | undefined>();
 
   useEffect(() => {
     const { projectId, groupId, groupName, testCaseId, executionId } = dashboardParams;
     if (!projectId || (!groupId && !groupName)) {
       setData(getTEDashBoardData());
+      setResolvedExecutionId(undefined);
       return;
     }
 
@@ -188,6 +194,7 @@ export default function TEDashBoardController() {
 
     const loadDashboardGroup = async () => {
       setData(getTEDashBoardData());
+      setResolvedExecutionId(executionId);
 
       try {
         if (!groupId) {
@@ -207,6 +214,7 @@ export default function TEDashBoardController() {
 
           const resolvedGroupName = String(groupName ?? '');
           const filteredResults = filterDashboardResults(results, resolvedGroupName, testCaseId);
+          setResolvedExecutionId(executionId);
 
           setData(
             getTEDashBoardData({
@@ -218,23 +226,40 @@ export default function TEDashBoardController() {
           return;
         }
 
-        const statsExecutionId = executionId ?? groupId;
+        const isSameAsGroupId = String(executionId ?? '') === String(groupId ?? '');
+        const resolvedBasicIds: DashboardBasicIds =
+          !executionId || !testCaseId || isSameAsGroupId
+            ? await resolveDashboardBasicIdsByGroupId(projectId, groupId).catch((error) => {
+                console.error('[TEDashBoard] 테스트 기본 식별자 조회 실패:', error);
+                return {};
+              })
+            : {};
+        if (cancelled) return;
+
+        const shouldUseBasicExecutionId =
+          isSameAsGroupId &&
+          resolvedBasicIds.executionId &&
+          String(resolvedBasicIds.executionId) !== String(groupId);
+        const statsExecutionId = shouldUseBasicExecutionId
+          ? resolvedBasicIds.executionId
+          : executionId ?? resolvedBasicIds.executionId;
         const [group, results, stats] = await Promise.all([
           fetchTestDashboardGroup(projectId, groupId),
           fetchProjectTestSummaryList(projectId, groupId).catch((error) => {
             console.error('[TEDashBoard] 테스트 코드 목록 조회 실패:', error);
             return [];
           }),
-          fetchTestExecutionStats(projectId, statsExecutionId).catch((error) => {
-            console.error('[TEDashBoard] 테스트 통계 조회 실패:', error);
-            return null;
-          }),
+          statsExecutionId
+            ? fetchTestExecutionStats(projectId, statsExecutionId).catch((error) => {
+                console.error('[TEDashBoard] 테스트 통계 조회 실패:', error);
+                return null;
+              })
+            : Promise.resolve(null),
         ]);
         if (cancelled) return;
 
-        const resolvedTestCaseId =
-          testCaseId ?? (await resolveTestCaseIdByGroupId(projectId, groupId));
-        if (cancelled) return;
+        const resolvedTestCaseId = testCaseId ?? resolvedBasicIds.testCaseId;
+        setResolvedExecutionId(statsExecutionId);
 
         setData(
           getTEDashBoardData({
@@ -311,14 +336,16 @@ export default function TEDashBoardController() {
   };
 
   const handleDownloadTestPlan = async () => {
-    const { projectId, executionId } = dashboardParams;
+    const { projectId } = dashboardParams;
+    const executionId = resolvedExecutionId ?? dashboardParams.executionId;
     if (!projectId || !executionId) return;
 
     await downloadTestPlan(projectId, executionId);
   };
 
   const handleDownloadTestReport = async () => {
-    const { projectId, executionId } = dashboardParams;
+    const { projectId } = dashboardParams;
+    const executionId = resolvedExecutionId ?? dashboardParams.executionId;
     if (!projectId || !executionId) return;
 
     const downloadData = await downloadTestDashboardReport(projectId, executionId);

--- a/src/pages/TEDashBoard/TEDashBoardModel.ts
+++ b/src/pages/TEDashBoard/TEDashBoardModel.ts
@@ -56,6 +56,7 @@ const mapResultToTestCodeItem = (
 ): TestCodeItem => {
   const id = toOptionalText(result.testCaseId) ?? toOptionalText(result.id);
   const title =
+    toOptionalText(result.CaseName) ??
     toOptionalText(result.testCodeName) ??
     toOptionalText(result.testCaseName) ??
     toOptionalText(result.testGroupName) ??

--- a/src/pages/TEDashBoard/TEDashBoardModel.ts
+++ b/src/pages/TEDashBoard/TEDashBoardModel.ts
@@ -68,6 +68,8 @@ const mapResultToTestCodeItem = (
     title,
     status: normalizeStatus(result.status),
     resultId: toNumericIdText(result.resultId ?? result.testResultId ?? result.id),
+    groupId: toNumericIdText(result.groupId ?? result.testGroupId),
+    executionId: toNumericIdText(result.executionId),
     passRatio: toOptionalText(result.passRatio),
     duration: toOptionalText(result.duration) ?? toOptionalText(result.testDuration),
     user: toOptionalText(result.tester) ?? toOptionalText(result.testerName),


### PR DESCRIPTION
## 📝 PR 설명
테스트 대시보드에서 `groupId`와 `executionId`를 동일하게 처리하던 문제를 수정하고, 하나의 그룹 안에 여러 시나리오 테스트가 있을 때 각 테스트가 분리되어 보이도록 반영했습니다.

## 🛠 주요 변경 사항
- 테스트 계획서/결과 보고서 다운로드 및 통계 조회 시 `groupId`가 아닌 실제 `executionId`를 사용하도록 수정
- `/tests/list/basic` 응답의 `executionId`를 기반으로 대시보드 이동/조회 로직 보완
- 여러 시나리오 선택 시 프로젝트 관리/대시보드에서 테스트가 하나로 합쳐지지 않고 시나리오별로 분리되어 표시되도록 수정
- 최초 표시명은 `입력값 (시나리오 가이드명)` 형태로 보이도록 반영

## 🧪 테스트 체크리스트
- [x] 테스트 계획서 다운로드 시 실제 `executionId`로 호출되는지 확인
- [x] 테스트 결과 보고서 다운로드 시 실제 `executionId`로 호출되는지 확인
- [x] 시나리오 2개 이상 선택 후 대시보드에서 테스트 결과가 모두 표시되는지 확인
- [x] 프로젝트 관리 대시보드에서 `입력값 (시나리오 가이드명)` 형태로 테스트명이 분리 표시되는지 확인

## 📸 스크린샷 또는 비디오
<!-- UI 확인 후 필요 시 첨부 예정 -->

## ➕ 추가 사항
현재 테스트명 수정 API는 `groupId` 기준으로 동작하고 있어, 같은 그룹 안의 시나리오별 테스트명을 완전히 독립적으로 수정하려면 백엔드에서 `executionId` 기준 수정 API가 추가로 필요할 수 있습니다.

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 코드를 제거했습니다
- [x] 주석 처리를 필요한 만큼 하였습니다.
- [ ] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)